### PR TITLE
downgrades psycop2 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-q==1.3.9
 djangorestframework==3.9.2
 gunicorn==20.1.0
 idna==3.3
-psycopg2==2.9.3
+psycopg2==2.8.6
 python-dateutil==2.8.2
 python-decouple==3.6
 pytz==2021.3


### PR DESCRIPTION
Downgrades psycop2 because the new update in psycop2 2.9 fails with Django 2.2.

This issue prevented the use of the django api admin.

**Error described in github issue:**
_Psycopg 2.9 changed the value passed to tzinfo_factory from an int to a timedelta. Django 2.2 (possibly newer but I'm on 2.2) has a check for offset == 0 and since timedelta(0) != 0 it goes boom._