### PR TITLE
Feature/add initial sync class tests

### DIFF
--- a/playlist_connect_api/sync.py
+++ b/playlist_connect_api/sync.py
@@ -1,4 +1,3 @@
-
 import requests
 import base64
 import json
@@ -125,7 +124,7 @@ class StartSync:
             response = requests.get(url, headers=header, timeout=10)
             # return response content
             if response.status_code and response.content:
-                if response.status_code != 200:
+                if response.status_code >= 400:
                     print(
                         f"400 level response from {service} GET, \
                             url: {url}, code: {response.status_code}"
@@ -319,6 +318,25 @@ class StartSync:
     @staticmethod
     def sync(playlistPairObject):
         """Syncs one Spotify and one Apple Music playlist together"""
+
+        if not playlistPairObject:
+            print("No playlist pair object passed")
+            return [0, 0]
+        elif not (
+            playlistPairObject.apple_token_1 and
+            playlistPairObject.apple_token_2 and
+            playlistPairObject.apple_token_3 and
+            playlistPairObject.spotify_token_1 and
+            playlistPairObject.spotify_token_2 and
+            playlistPairObject.spotify_token_3 and
+            playlistPairObject.spotify_refresh_1 and
+            playlistPairObject.spotify_refresh_2 and
+            playlistPairObject.apple_playlist_id and
+            playlistPairObject.spotify_playlist_id
+        ):
+            print("Playlist pair object with wrong/no params")
+            return [0, 0]
+
         spotify_auth = base64.b64decode(
             f"{playlistPairObject.spotify_token_1}\
                 {playlistPairObject.spotify_token_2}\

--- a/playlist_connect_api/tests.py
+++ b/playlist_connect_api/tests.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from playlist_connect_api.models import PlaylistPairs
-# from playlist_connect_api.sync import StartSync
+from playlist_connect_api.sync import StartSync
 
 
 class PlaylistPairTestCase(TestCase):
@@ -59,4 +59,87 @@ class PlaylistPairTestCase(TestCase):
         self.assertEqual(
             second_playlist_pair.__str__(),
             "apple-apple_playlist_id_2_spotify-spotify_playlist_id_2"
+        )
+
+
+class StartSyncTestCase(TestCase):
+    def test_sync_no_object(self):
+        """Tests function with no object passed"""
+        self.assertEqual(
+            StartSync.sync(""),
+            [0, 0]
+        )
+
+    def test_sync_no_params(self):
+        """Tests function with no params in object"""
+        mockPlaylistPair = type('', (), {
+            "apple_token_1": "",
+            "apple_token_2": "",
+            "apple_token_3": "",
+            "spotify_token_1": "",
+            "spotify_token_2": "",
+            "spotify_token_3": "",
+            "spotify_refresh_1": "",
+            "spotify_refresh_2": "",
+            "apple_playlist_id": "",
+            "spotify_playlist_id": ""
+        })()
+
+        self.assertEqual(
+            StartSync.sync(mockPlaylistPair),
+            [0, 0]
+        )
+
+    def test_sync_half_params(self):
+        """Tests function with half params in object"""
+        mockPlaylistPair = type('', (), {
+            "apple_token_1": "test",
+            "apple_token_2": "test",
+            "apple_token_3": "test",
+            "spotify_token_1": "test",
+            "spotify_token_2": "test",
+            "spotify_token_3": "",
+            "spotify_refresh_1": "",
+            "spotify_refresh_2": "",
+            "apple_playlist_id": "",
+            "spotify_playlist_id": ""
+        })()
+
+        self.assertEqual(
+            StartSync.sync(mockPlaylistPair),
+            [0, 0]
+        )
+
+    def test_api_get(self):
+        """Tests api GET function"""
+        mockHeader = {
+            "Authorization": "",
+        }
+        self.assertEqual(
+            StartSync.api_get(
+                'spotify',
+                'http://example.com',
+                mockHeader
+            ).status_code,
+            200
+        )
+
+    def test_api_post(self):
+        """Tests api POST function"""
+        mockHeader = {
+            "Authorization": "",
+        }
+        mockPayload = {
+            "mock1": "",
+            "mock2": "",
+            "mock3": "",
+        }
+        self.assertEqual(
+            StartSync.api_post(
+                'spotify',
+                'http://example.com',
+                mockHeader,
+                mockPayload
+            ).status_code,
+            200
         )


### PR DESCRIPTION
This pull request:

Adds:
- tests for functions in the StartSync class
  - tests for the sync() function
  - tests for the api_get() function
  - tests for the api_post() function

Updates:
- a conditional for the response.status_code return value in api_get()
- the sync function to test against no PlaylistPair object being passed
- the sync function to test against the PlaylistPair object being passed with no parameters
- the sync function to test against the PlaylistPair object being passed with half of the parameters
